### PR TITLE
Add Prayer model

### DIFF
--- a/app/models/prayer.rb
+++ b/app/models/prayer.rb
@@ -1,0 +1,7 @@
+class Prayer < ActiveRecord::Base
+  belongs_to :user
+  belongs_to :resident
+  belongs_to :route, optional: true
+
+  validates :recorded_at, presence: true
+end

--- a/db/migrate/20240522224806_create_prayers.rb
+++ b/db/migrate/20240522224806_create_prayers.rb
@@ -1,0 +1,11 @@
+class CreatePrayers < ActiveRecord::Migration[7.1]
+  def change
+    create_table :prayers do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :resident, null: false, foreign_key: true
+      t.references :route, null: true, foreign_key: true
+
+      t.datetime :recorded_at, null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_17_202631) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_22_224806) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -21,6 +21,16 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_17_202631) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_commitments_on_user_id"
+  end
+
+  create_table "prayers", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "resident_id", null: false
+    t.bigint "route_id"
+    t.datetime "recorded_at", null: false
+    t.index ["resident_id"], name: "index_prayers_on_resident_id"
+    t.index ["route_id"], name: "index_prayers_on_route_id"
+    t.index ["user_id"], name: "index_prayers_on_user_id"
   end
 
   create_table "residents", force: :cascade do |t|
@@ -62,6 +72,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_17_202631) do
   end
 
   add_foreign_key "commitments", "users"
+  add_foreign_key "prayers", "residents"
+  add_foreign_key "prayers", "routes"
+  add_foreign_key "prayers", "users"
   add_foreign_key "routes", "commitments"
   add_foreign_key "routes", "users"
 end

--- a/spec/factories/prayer.rb
+++ b/spec/factories/prayer.rb
@@ -1,0 +1,9 @@
+
+FactoryBot.define do
+  factory :prayer do
+    user
+    route
+    resident
+    recorded_at { DateTime.current }
+  end
+end

--- a/spec/models/prayer_spec.rb
+++ b/spec/models/prayer_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+RSpec.describe Prayer, :model do
+  describe 'associations' do
+    it 'must have a user' do
+      expect do
+        build(:prayer, user: nil).save!
+      end.to raise_error(ActiveRecord::NotNullViolation)
+    end
+
+    it "must have a resident" do
+      expect do
+        build(:prayer, resident: nil).save!
+      end.to raise_error(ActiveRecord::NotNullViolation)
+    end
+
+    it "may have a route" do
+      expect { build(:prayer, route: nil).save! }.not_to raise_error
+    end
+  end
+
+  describe 'validations' do
+    let(:attributes) { attributes_for(:prayer) }
+
+    it 'is valid from the factory' do
+      expect(create(:prayer)).to be_valid
+    end
+  end
+end


### PR DESCRIPTION
This commit adds a Prayer model to track prayers made by the user. A prayer must have a User and the Resident that the user has prayed for. A prayer may optionally have a Route if the prayer was made while the user was on a route. The prayer also has a timestamp to record when the prayer was made.