### PR TITLE
Isaac/add journeys

### DIFF
--- a/app/models/devotional.rb
+++ b/app/models/devotional.rb
@@ -1,18 +1,5 @@
-# require 'aws-record'
-
-class DevotionalNoIdError < StandardError; end
-class Devotional
-  # include Aws::Record
-  # set_table_name ENV['DEVOTIONAL_TABLE_NAME']
-
-  # integer_attr  :id,   hash_key: true
-  # string_attr   :title
-  # string_attr   :url
-  # string_attr   :img_url
-
-  def self.new_devotional(data)
-    devo = new(data)
-    devo.save!
-    devo
-  end
+class Devotional < ActiveRecord::Base
+  validates :title, presence: true, uniqueness: true
+  validates :url, presence: true
+  validates :img_url, presence: true
 end

--- a/app/models/journey.rb
+++ b/app/models/journey.rb
@@ -1,21 +1,10 @@
-# require 'aws-record'
+# frozen_string_literal: true
 
-# class JourneyNoIdError < StandardError; end
-# class Journey < Sequel::Model
-  # def initialize(attrs)
-  #   super(attrs)
-  # end
-  # include Aws::Record
-  # set_table_name ENV["JOURNEY_TABLE_NAME"]
+class Journey < ActiveRecord::Base
+  validates :annual_miles, presence: true, numericality: true
+  validates :monthly_miles, presence: true, numericality: true
+  validates :weekly_miles, presence: true, numericality: true
+  validates :title, presence: true, uniqueness: true
 
-  # string_attr  :title,       hash_key: true
-  # integer_attr :target_miles
-  # string_attr  :graphic_url
-
-  # def self.new_journey(*data)
-  #   binding.pry
-  #   journey = new(*data)
-  #   journey.save!
-  #   journey
-  # end
-# end
+  MILEAGE_CONVERSION_FACTOR = 0.01
+end

--- a/db/migrate/20240617163508_create_journeys.rb
+++ b/db/migrate/20240617163508_create_journeys.rb
@@ -1,0 +1,10 @@
+class CreateJourneys < ActiveRecord::Migration[7.1]
+  def change
+    create_table :journeys do |t|
+      t.integer :annual_miles, null: false
+      t.integer :monthly_miles, null: false
+      t.integer :weekly_miles, null: false
+      t.string :title, null: false, index: { unique: true }
+    end
+  end
+end

--- a/db/migrate/20240617192115_create_devotionals.rb
+++ b/db/migrate/20240617192115_create_devotionals.rb
@@ -1,0 +1,9 @@
+class CreateDevotionals < ActiveRecord::Migration[7.1]
+  def change
+    create_table :devotionals do |t|
+      t.string :title, null: false, index: { unique: true }
+      t.string :url, null: false
+      t.string :img_url, null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_17_163508) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_17_192115) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -21,6 +21,13 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_17_163508) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_commitments_on_user_id"
+  end
+
+  create_table "devotionals", force: :cascade do |t|
+    t.string "title", null: false
+    t.string "url", null: false
+    t.string "img_url", null: false
+    t.index ["title"], name: "index_devotionals_on_title", unique: true
   end
 
   create_table "journeys", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_22_224806) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_17_163508) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -21,6 +21,14 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_22_224806) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_commitments_on_user_id"
+  end
+
+  create_table "journeys", force: :cascade do |t|
+    t.integer "annual_miles", null: false
+    t.integer "monthly_miles", null: false
+    t.integer "weekly_miles", null: false
+    t.string "title", null: false
+    t.index ["title"], name: "index_journeys_on_title", unique: true
   end
 
   create_table "prayers", force: :cascade do |t|

--- a/spec/factories/devotional.rb
+++ b/spec/factories/devotional.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :devotional do
+    sequence :title do |n|
+      "Daily Bread #{n}"
+    end
+    url { 'https://dailybread.com' }
+    img_url { 'https://dailybread.com/img.jpg' }
+  end
+end

--- a/spec/factories/journey.rb
+++ b/spec/factories/journey.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :journey do
+    annual_miles { 36_500 }
+    monthly_miles { 3_000 }
+    weekly_miles { 700 }
+    sequence :title do |n|
+      "My Journey #{n}"
+    end
+  end
+end

--- a/spec/models/devotional_spec.rb
+++ b/spec/models/devotional_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+
+RSpec.describe Devotional, :model do
+  let (:valid_attributes) { attributes_for(:devotional) }
+
+  describe 'validations' do
+    it 'is valid from the factory' do
+      expect(described_class.new(valid_attributes)).to be_valid
+    end
+
+    it 'creates a valid list' do
+      expect(create_list(:devotional, 2).last).to be_valid
+    end
+
+    it 'requires title' do
+      devotional = build(:devotional, title: '')
+
+      expect(devotional).not_to be_valid
+      expect(devotional.errors.messages).to include(
+        { title: ['can\'t be blank'] }
+      )
+    end
+
+    it 'requires title to be unique' do
+      create(:devotional, title: 'Daily Bread')
+      devotional = build(:devotional, title: 'Daily Bread')
+
+      expect(devotional).not_to be_valid
+      expect(devotional.errors.messages).to include(
+        { title: ['has already been taken'] }
+      )
+    end
+
+    it 'requires url' do
+      devotional = build(:devotional, url: '')
+
+      expect(devotional).not_to be_valid
+      expect(devotional.errors.messages).to include(
+        { url: ['can\'t be blank'] }
+      )
+    end
+
+    it 'requires img_url' do
+      devotional = build(:devotional, img_url: '')
+
+      expect(devotional).not_to be_valid
+      expect(devotional.errors.messages).to include(
+        { img_url: ['can\'t be blank'] }
+      )
+    end
+  end
+end

--- a/spec/models/journey_spec.rb
+++ b/spec/models/journey_spec.rb
@@ -1,0 +1,88 @@
+require 'spec_helper'
+
+RSpec.describe Journey, :model do
+  let (:valid_attributes) { attributes_for(:journey) }
+
+  describe 'validations' do
+    it 'is valid from the factory' do
+      expect(described_class.new(valid_attributes)).to be_valid
+    end
+
+    it 'creates a valid list' do
+      expect(create_list(:journey, 2).last).to be_valid
+    end
+
+    it 'requires annual_miles' do
+      journey = build(:journey, annual_miles: '')
+
+      expect(journey).not_to be_valid
+      expect(journey.errors.messages).to include(
+        { annual_miles: ['can\'t be blank', 'is not a number'] }
+      )
+    end
+
+    it 'requires annual_miles to be a number' do
+      journey = build(:journey, annual_miles: 'abc')
+
+      expect(journey).not_to be_valid
+      expect(journey.errors.messages).to include(
+        { annual_miles: ['is not a number'] }
+      )
+    end
+
+    it 'requires monthly_miles' do
+      journey = build(:journey, monthly_miles: '')
+
+      expect(journey).not_to be_valid
+      expect(journey.errors.messages).to include(
+        { monthly_miles: ['can\'t be blank', 'is not a number'] }
+      )
+    end
+
+    it 'requires monthly_miles to be a number' do
+      journey = build(:journey, monthly_miles: 'abc')
+
+      expect(journey).not_to be_valid
+      expect(journey.errors.messages).to include(
+        { monthly_miles: ['is not a number'] }
+      )
+    end
+
+    it 'requires weekly_miles' do
+      journey = build(:journey, weekly_miles: '')
+
+      expect(journey).not_to be_valid
+      expect(journey.errors.messages).to include(
+        { weekly_miles: ['can\'t be blank', 'is not a number'] }
+      )
+    end
+
+    it 'requires weekly_miles to be a number' do
+      journey = build(:journey, weekly_miles: 'abc')
+
+      expect(journey).not_to be_valid
+      expect(journey.errors.messages).to include(
+        { weekly_miles: ['is not a number'] }
+      )
+    end
+
+    it 'requires a title' do
+      journey = build(:journey, title: '')
+
+      expect(journey).not_to be_valid
+      expect(journey.errors.messages).to include(
+        { title: ['can\'t be blank'] }
+      )
+    end
+
+    it 'requires a unique title' do
+      first_journey = create(:journey)
+      journey = build(:journey, title: first_journey.title)
+
+      expect(journey).not_to be_valid
+      expect(journey.errors.messages).to include(
+        { title: ['has already been taken'] }
+      )
+    end
+  end
+end


### PR DESCRIPTION
This PR adds the Journey model as well as the Devotional model. I did run into one issue when testing the Journey model. I needed to test that the numeric values were not blank. In order to make them blank I had to give them a blank string, which also threw an error because the value was not of the correct type. I tried using nil but still got the same error. I ended up adding the error message to the expected output to get the test to pass. Is there some better way to test a numerical value not being blank without using a blank string? Hope that makes sense. Everything else was pretty straight forward.