### PR TITLE
Zac/create prayers

### DIFF
--- a/app/app.rb
+++ b/app/app.rb
@@ -5,102 +5,80 @@ require 'sinatra'
 require 'sinatra/activerecord'
 require 'sinatra/cors'
 require_relative './models'
+require_relative './middleware/authentication'
 
 set :database_file, '../config/database.yml'
 
 set :allow_origin, '*'
 set :allow_methods, 'GET,POST,DELETE,PATCH,OPTIONS'
 set :allow_headers,
-    'X-Requested-With, X-HTTP-Method-Override, Content-Type, Cache-Control, Accept, if-modified-since, P4L-email'
+    'X-Requested-With, X-HTTP-Method-Override, Content-Type, Cache-Control, Accept, if-modified-since, HTTP_P4L_EMAIL'
 set :expose_headers, 'location,link'
 
 puts "RACK_ENV: #{ENV['RACK_ENV']}"
 
-get '/user' do
-  email = request.fetch_header('P4L-email')
-  user = User.find_by_email(email)
+use Authentication::Cognito
 
+before do
   content_type :json
-  user.to_json
+end
 
-rescue KeyError
-  status 400
-  body {}
+get '/user' do
+  user_from_token.to_json
 end
 
 get '/user/residents' do
-  email = request.fetch_header('P4L-email')
-  user = User.find_by_email(email)
+  residents = Resident.where(user_id: user_from_token&.id)
 
-  residents = Resident.where(user_id: user&.id)
-
-  content_type :json
   residents.to_json
-
-rescue KeyError
-  status 400
-  body {}
 end
 
 get '/user/residents/next-resident' do
-  email = request.fetch_header('P4L-email')
-  user = User.find_by_email(email)
-
   # TODO: Look at eager loading here. We might be able to grab the resident for
   # the last Prayer at the same time, or use a plain AR query to grab the next
   # Resident without instantiating the objects in between:
   # user.residents.where('position > ?', last_prayer.resident.position).limit(1).first
-  last_prayer = Prayer.where(user_id: user&.id).order(recorded_at: :desc).limit(1).first
+  last_prayer = Prayer.where(user_id: user_from_token&.id).order(recorded_at: :desc).limit(1).first
   next_resident = if last_prayer.nil?
-                    user.residents.limit(1).first
+                    user_from_token.residents.limit(1).first
                   else
                     last_prayer.resident.next_resident
                   end
 
-  content_type :json
   next_resident.to_json
-
-rescue KeyError
-  status 400
-  body {}
 end
 
 get '/user/residents/:id' do
-  email = request.fetch_header('P4L-email')
-  user = User.find_by_email(email)
+  resident = Resident.find_by(id: params[:id], user_id: user_from_token&.id)
 
-  resident = Resident.find_by(id: params[:id], user_id: user&.id)
-
-  content_type :json
   resident.to_json
-
-rescue KeyError
-  status 400
-  body {}
 end
 
 post '/prayers' do
-  email = request.fetch_header('P4L-email')
-  user = User.find_by_email(email)
-
   resident_id = params.fetch('resident_id')
-  prayer = Prayer.new(resident_id:, user_id: user&.id, recorded_at: Time.current)
+  prayer = Prayer.new(resident_id:, user_id: user_from_token&.id, recorded_at: Time.current)
   prayer.save!
 
   next_resident = prayer.resident.next_resident
 
-
-  content_type :json
   status 201
   prayer.attributes.merge(
     { 'next_resident_id' => next_resident.id }
   ).to_json
-rescue KeyError => e
-  status 400
-  body [{ errors: ["Missing param: #{e.key}"] }.to_json]
 end
 
 error ActiveRecord::RecordInvalid do |error|
   status 422
   body [{ errors: error.message.to_s }.to_json]
+end
+
+error KeyError do |error|
+  status 400
+  body [{ errors: ["Missing param: #{error.key}"] }.to_json]
+end
+
+private
+
+def user_from_token
+  @user_from_token ||= env[:user]
 end

--- a/app/middleware/authentication.rb
+++ b/app/middleware/authentication.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Authentication
+  class Cognito
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      email = Rack::Request.new(env).fetch_header('HTTP_P4L_EMAIL') { nil }
+      user = User.find_by_email(email)
+
+      if user
+        env[:user] = user
+        @app.call(env)
+      else
+        Rack::Response.new({ data: '', errors: 'Unauthorized' }.to_json, 401, {}).finish
+      end
+    end
+  end
+end

--- a/app/models/prayer.rb
+++ b/app/models/prayer.rb
@@ -6,4 +6,5 @@ class Prayer < ActiveRecord::Base
   belongs_to :route, optional: true
 
   validates :recorded_at, presence: true
+  validates :resident, presence: true
 end

--- a/spec/models/prayer_spec.rb
+++ b/spec/models/prayer_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Prayer, :model do
     it "must have a resident" do
       expect do
         build(:prayer, resident: nil).save!
-      end.to raise_error(ActiveRecord::NotNullViolation)
+      end.to raise_error(ActiveRecord::RecordInvalid)
     end
 
     it "may have a route" do

--- a/spec/requests/prayers_spec.rb
+++ b/spec/requests/prayers_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Prayer endpoints', :request do
   let(:user) { create(:user) }
   let(:headers) do
     {
-      'P4L-email' => user.email
+      'HTTP_P4L_EMAIL' => user.email
     }
   end
 
@@ -24,8 +24,8 @@ RSpec.describe 'Prayer endpoints', :request do
     it 'requires the email header' do
       post '/prayers', valid_params, {}
 
-      expect(last_response.status).to eq(400)
-      expect(parsed_response['errors']).to include('Missing param: P4L-email')
+      expect(last_response.status).to eq(401)
+      expect(parsed_response['errors']).to include('Unauthorized')
     end
 
     it 'creates a Prayer' do

--- a/spec/requests/prayers_spec.rb
+++ b/spec/requests/prayers_spec.rb
@@ -1,0 +1,66 @@
+require 'spec_helper'
+
+RSpec.describe 'Prayer endpoints', :request do
+  include Rack::Test::Methods
+  include ApiSpecHelpers
+
+  let(:app) { Sinatra::Application }
+  let(:user) { create(:user) }
+  let(:headers) do
+    {
+      'P4L-email' => user.email
+    }
+  end
+
+  describe 'POST /prayers' do
+    let!(:resident) { create(:resident, user:) }
+
+    let(:valid_params) do
+      {
+        resident_id: resident.id
+      }
+    end
+
+    it 'requires the email header' do
+      post '/prayers', valid_params, {}
+
+      expect(last_response.status).to eq(400)
+      expect(parsed_response['errors']).to include('Missing param: P4L-email')
+    end
+
+    it 'creates a Prayer' do
+      expect do
+        post '/prayers', valid_params, headers
+      end.to change { Prayer.count }.by(1)
+    end
+
+    it 'returns the next Resident for the User' do
+      bob = create(:resident, user:, position: resident.position + 1)
+
+      post '/prayers', valid_params, headers
+      expect(last_response.status).to eq(201)
+
+      expect(parsed_response).to include(
+        data_object_for(Prayer.last).merge('next_resident_id' => bob.id)
+      )
+    end
+
+    it 'returns an error response for a malformed request' do
+      invalid_params = { taco_id: resident.id }
+
+      post '/prayers', invalid_params, headers
+
+      expect(last_response.status).to eq(400)
+      expect(parsed_response['errors']).to include('Missing param: resident_id')
+    end
+
+    it 'returns an error response for invalid data' do
+      invalid_params = { resident_id: Resident.maximum(:id) + 1 }
+
+      post '/prayers', invalid_params, headers
+
+      expect(last_response.status).to eq(422)
+      expect(parsed_response['errors']).to include("Validation failed: Resident can't be blank")
+    end
+  end
+end

--- a/spec/requests/user_spec.rb
+++ b/spec/requests/user_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'User endpoints', :request do
   let(:chad) { create(:resident, name: 'Chad the third', position: 3) }
   let(:headers) do
     {
-      'P4L-email' => user.email
+      'HTTP_P4L_EMAIL' => user.email
     }
   end
 
@@ -27,8 +27,8 @@ RSpec.describe 'User endpoints', :request do
     it 'returns an error when the email is not sent' do
       get '/user', {}, {}
 
-      expect(last_response.status).to eq(400)
-      expect(last_response.body).to be_empty
+      expect(last_response.status).to eq(401)
+      expect(parsed_response).to eq({ 'data' => '', 'errors' => 'Unauthorized' })
     end
   end
 
@@ -60,16 +60,16 @@ RSpec.describe 'User endpoints', :request do
       it 'returns an error response when the email is not sent' do
         get '/user/residents', {}, {}
 
-        expect(last_response.status).to eq(400)
-        expect(last_response.body).to be_empty
+        expect(last_response.status).to eq(401)
+        expect(parsed_response).to eq({ 'data' => '', 'errors' => 'Unauthorized' })
       end
 
-      it 'returns an empty response if the wrong email is sent' do
-        not_the_user_email = { 'P4L-email' => 'vladimir@hacking.ru' }
+      it 'returns an unauthorized response if the wrong email is sent' do
+        not_the_user_email = { 'HTTP_P4L_EMAIL' => 'vladimir@hacking.ru' }
         get '/user/residents', {}, not_the_user_email
 
-        expect(last_response.status).to eq(200)
-        expect(parsed_response).to match([])
+        expect(last_response.status).to eq(401)
+        expect(parsed_response).to eq({ 'data' => '', 'errors' => 'Unauthorized' })
       end
     end
   end
@@ -80,8 +80,8 @@ RSpec.describe 'User endpoints', :request do
     it 'requires the email header' do
       get "/user/residents/#{alice.id}", {}, {}
 
-      expect(last_response.status).to eq(400)
-      expect(last_response.body).to be_empty
+      expect(last_response.status).to eq(401)
+      expect(parsed_response).to eq({ 'data' => '', 'errors' => 'Unauthorized' })
     end
 
     it 'returns the resident' do


### PR DESCRIPTION
Add route to POST Prayers

This route creates a new Prayer for the User and includes the ID of the next Resident in the list to minimize the number of requests we need to make.

There is a new validation on Prayers which ensures that we aren't trying to save one without a Resident and raising a database-level error, resulting in a 500 status. This is a client error,  so we need to return a 4xx status.