### PR TITLE
Add authentication spec helpers

### DIFF
--- a/spec/requests/prayers_spec.rb
+++ b/spec/requests/prayers_spec.rb
@@ -3,14 +3,10 @@ require 'spec_helper'
 RSpec.describe 'Prayer endpoints', :request do
   include Rack::Test::Methods
   include ApiSpecHelpers
+  include AuthenticationSpecHelpers
 
   let(:app) { Sinatra::Application }
-  let(:user) { create(:user) }
-  let(:headers) do
-    {
-      'HTTP_P4L_EMAIL' => user.email
-    }
-  end
+  let(:user) { authenticated }
 
   describe 'POST /prayers' do
     let!(:resident) { create(:resident, user:) }

--- a/spec/requests/user_spec.rb
+++ b/spec/requests/user_spec.rb
@@ -6,15 +6,11 @@ RSpec.describe 'User endpoints', :request do
   include AuthenticationSpecHelpers
 
   let(:app) { Sinatra::Application }
-  let(:user) { create(:user) }
+  let!(:user) { authenticated(create(:user, residents:)) }
   let(:alice) { create(:resident, name: 'Alice the first', position: 1) }
   let(:bob) { create(:resident, name: 'Bob the second', position: 2) }
   let(:chad) { create(:resident, name: 'Chad the third', position: 3) }
-  let(:headers) do
-    {
-      'HTTP_P4L_EMAIL' => user.email
-    }
-  end
+  let(:residents) { [alice, bob, chad] }
 
   describe 'GET /user' do
     it 'returns the User with the given email' do
@@ -35,6 +31,8 @@ RSpec.describe 'User endpoints', :request do
 
   describe 'GET /user/residents' do
     context 'when there are no Residents' do
+      let(:residents) { [] }
+
       it 'returns an empty response' do
         get '/user/residents', {}, headers
 
@@ -44,8 +42,6 @@ RSpec.describe 'User endpoints', :request do
     end
 
     context 'when the User owns the Residents' do
-      let!(:residents) { create_list(:resident, 3, user:) }
-
       it 'returns the Residents ordered by position' do
         get '/user/residents', {}, headers
 
@@ -76,8 +72,6 @@ RSpec.describe 'User endpoints', :request do
   end
 
   describe 'GET /user/residents/' do
-    let!(:user) { create(:user, residents: [alice, bob, chad]) }
-
     it 'requires the email header' do
       get "/user/residents/#{alice.id}", {}, {}
 
@@ -94,8 +88,6 @@ RSpec.describe 'User endpoints', :request do
   end
 
   describe 'GET /user/residents/next-resident' do
-    let(:user) { create(:user, residents: [alice, bob, chad]) }
-
     it 'returns the first Resident if there are no Prayers' do
       get '/user/residents/next-resident', {}, headers
 

--- a/spec/requests/user_spec.rb
+++ b/spec/requests/user_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 RSpec.describe 'User endpoints', :request do
   include Rack::Test::Methods
   include ApiSpecHelpers
+  include AuthenticationSpecHelpers
 
   let(:app) { Sinatra::Application }
   let(:user) { create(:user) }
@@ -28,7 +29,7 @@ RSpec.describe 'User endpoints', :request do
       get '/user', {}, {}
 
       expect(last_response.status).to eq(401)
-      expect(parsed_response).to eq({ 'data' => '', 'errors' => 'Unauthorized' })
+      expect(parsed_response).to eq(unauthorized_response)
     end
   end
 
@@ -61,7 +62,7 @@ RSpec.describe 'User endpoints', :request do
         get '/user/residents', {}, {}
 
         expect(last_response.status).to eq(401)
-        expect(parsed_response).to eq({ 'data' => '', 'errors' => 'Unauthorized' })
+        expect(parsed_response).to eq(unauthorized_response)
       end
 
       it 'returns an unauthorized response if the wrong email is sent' do
@@ -69,7 +70,7 @@ RSpec.describe 'User endpoints', :request do
         get '/user/residents', {}, not_the_user_email
 
         expect(last_response.status).to eq(401)
-        expect(parsed_response).to eq({ 'data' => '', 'errors' => 'Unauthorized' })
+        expect(parsed_response).to eq(unauthorized_response)
       end
     end
   end
@@ -81,7 +82,7 @@ RSpec.describe 'User endpoints', :request do
       get "/user/residents/#{alice.id}", {}, {}
 
       expect(last_response.status).to eq(401)
-      expect(parsed_response).to eq({ 'data' => '', 'errors' => 'Unauthorized' })
+      expect(parsed_response).to eq(unauthorized_response)
     end
 
     it 'returns the resident' do

--- a/spec/support/helpers/authentication_spec_helpers.rb
+++ b/spec/support/helpers/authentication_spec_helpers.rb
@@ -1,14 +1,19 @@
 # frozen_string_literal: true
 
 module AuthenticationSpecHelpers
-  def authenticated_user(user)
-    # authenticate a user
-    # create one if you need to
-    # return the user
+  def authenticated(user = FactoryBot.create(:user))
+    headers.merge!(user_token_header(user))
+    user
   end
 
-  def is_authenticated?(user)
-    # tell me if this user has been authenticated
+  def headers
+    @headers ||= {}
+  end
+
+  def user_token_header(user)
+    {
+      'HTTP_P4L_EMAIL' => user.email
+    }
   end
 
   def unauthorized_response

--- a/spec/support/helpers/authentication_spec_helpers.rb
+++ b/spec/support/helpers/authentication_spec_helpers.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module AuthenticationSpecHelpers
+  def authenticated_user(user)
+    # authenticate a user
+    # create one if you need to
+    # return the user
+  end
+
+  def is_authenticated?(user)
+    # tell me if this user has been authenticated
+  end
+
+  def unauthorized_response
+    { 'data' => '', 'errors' => 'Unauthorized' }
+  end
+end


### PR DESCRIPTION
Here we add a module to help with the setup and expectations related to authentication in our request specs. This will help us to write consistent tests and not have to think too hard about how to properly set them up.

I'll likely squash this into one commit once approved.