### PR TITLE
Zac/quiet seed task specs

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,23 +1,19 @@
 # frozen_string_literal: true
 
+require './app/app'
 require 'sinatra/activerecord/rake'
 
 # Load all files in the lib directory
 Dir.glob('lib/*.rb').each { |file| require_relative file }
 
 namespace :db do
-  desc 'loads application'
-  task :load_config do
-    require './app/app'
-  end
-
   namespace :seed do
     desc "Seed users from /db/seeds/users.yml"
-    task :users => :load_config do
+    task :users => :environment do
       SeedUsers.run
     end
     desc "Seed verses from /db/seeds/verses.yml"
-    task :verses => :load_config do
+    task :verses => :environment do
       SeedVerses.run
     end
   end

--- a/lib/db_seed_verses.rb
+++ b/lib/db_seed_verses.rb
@@ -4,7 +4,7 @@ class SeedVerses
   def self.run
     verses = YAML.load_file('db/seeds/verses.yml')
     verses.each do |verse|
-      Verse.find_or_create_by(verse).save!
+      Verse.find_or_create_by!(verse)
     end
     puts Verse.count
     puts "Inserted #{verses.count} verses"

--- a/spec/tasks/seed_users_spec.rb
+++ b/spec/tasks/seed_users_spec.rb
@@ -1,20 +1,12 @@
 require 'spec_helper'
+require_relative '../../lib/db_seed_users'
 
 RSpec.describe 'Seeding the database with users', :task do
-  #  let(:valid_attributes) { attributes_for(:user) }
-
-  before(:all) do
-    Rake.application.init
-    Rake.application.load_rakefile
-    Rake::Task.define_task(:environment)
-    Rake::Task['db:seed:users'].invoke
-  end
-
   it 'creates the users' do
-    expect(User.count).to eq(1)
-  end
+    expect { SeedUsers.run }.to output(/Inserted 1 users/).to_stdout
 
-  it 'creates the first user' do
+    expect(User.count).to eq(1)
+
     user = User.first
     expect(user.first_name).to eq 'Isaac'
   end

--- a/spec/tasks/seed_verses_spec.rb
+++ b/spec/tasks/seed_verses_spec.rb
@@ -1,20 +1,14 @@
 require 'spec_helper'
+require_relative '../../lib/db_seed_verses'
 
 RSpec.describe 'Seeding the database with verses', :task do
   let(:valid_attributes) { attributes_for(:verse) }
 
-  before(:all) do
-    Rake.application.init
-    Rake.application.load_rakefile
-    Rake::Task.define_task(:environment)
-    Rake::Task['db:seed:verses'].invoke
-  end
-
   it 'creates the verses' do
-    expect(Verse.count).to eq(100)
-  end
+    expect { SeedVerses.run }.to output(/Inserted 100 verses/).to_stdout
 
-  it 'creates the first verse' do
+    expect(Verse.count).to eq(100)
+
     verse = Verse.first
     expect(verse.day).to eq 1
   end


### PR DESCRIPTION
Simplify User and Verse seed task specs
    
Rake tasks do not play nicely with DatabaseCleaner for some reason.
Since the logic is contained in a class, it tends to be much easier to
test, so rather than invoke the Rake task from within the test, we can
just call the class directly and save ourselves the headache.
    
When the tests are run, the output from the db:seed:verses task prints
to the console, which we'd generally want to avoid. Wrapping the
execution of the task with the `output` matcher will do this. Along
the way, we can clean up this test to not share state between examples.
    
We can also use the bang version of find_or_create_by to raise
validation errors without an explicit `save!`.