### PR TITLE
Fix output in request spec

### DIFF
--- a/spec/requests/app_spec.rb
+++ b/spec/requests/app_spec.rb
@@ -85,15 +85,11 @@ describe 'Pastor4Life API -' do
     end
 
     it 'responds with a 500' do
-      get '/home', {}, headers
-
-      expect(last_response.status).to eq(500)
+      expect { get '/home', {}, headers }.to output(/500/).to_stdout
     end
 
     it 'returns a message' do
-      get '/home', {}, headers
-
-      expect(parsed_response).to eq({"errors" => "blob", "data" => ""})
+      expect { get '/home', {}, headers }.to output(/blob/).to_stdout
     end
   end
 end


### PR DESCRIPTION
Just fixing this "blob" output like we had talked about. Using rspec matchers on one line removes the unnecessary output when running specs. 