### PR TITLE
Return whole Resident when posting a Prayer

### DIFF
--- a/app/app.rb
+++ b/app/app.rb
@@ -110,7 +110,7 @@ post '/prayers' do
 
   status 201
   prayer.attributes.merge(
-    { 'next_resident_id' => next_resident.id }
+    { 'next_resident' => next_resident }
   ).to_json
 end
 

--- a/spec/requests/prayers_spec.rb
+++ b/spec/requests/prayers_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe 'Prayer endpoints', :request do
       expect(last_response.status).to eq(201)
 
       expect(parsed_response).to include(
-        data_object_for(Prayer.last).merge('next_resident_id' => bob.id)
+        data_object_for(Prayer.last).merge('next_resident' => data_object_for(bob))
       )
     end
 


### PR DESCRIPTION
Rather than just returning the next Resident ID and using that to retrieve the Resident's name, we can cut out a whole HTTP request by simply returning the whole Resident object for the next Resident when a Prayer is created.