### PR TITLE
Zac/correct token payload

### DIFF
--- a/app/middleware/authentication.rb
+++ b/app/middleware/authentication.rb
@@ -11,7 +11,7 @@ module Authentication
       return unauthorized_response unless token
 
       decoded_token = JsonWebToken.new(token).verify!
-      user = User.find_by_sub(decoded_token.dig('data', 'sub'))
+      user = User.find_or_create_by(sub: decoded_token.fetch('sub'))
 
       if user
         env[:user] = user

--- a/spec/middleware/authentication_spec.rb
+++ b/spec/middleware/authentication_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'Authentication middleware' do
       instance_double(
         JsonWebToken,
         verify!: {
-          'data' => { 'sub' => user.sub },
+          'sub' => user.sub,
           'iss' => jwk[:issuer],
           'aud' => 'P4L-API'
         }

--- a/spec/models/commitment_spec.rb
+++ b/spec/models/commitment_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Commitment, :model do
     it 'belongs to a journey' do
       expect do
         build(:commitment, journey: nil).save!
-      end.to raise_error(ActiveRecord::NotNullViolation)
+      end.to raise_error(ActiveRecord::RecordInvalid)
     end
   end
 

--- a/spec/support/helpers/authentication_spec_helpers.rb
+++ b/spec/support/helpers/authentication_spec_helpers.rb
@@ -33,10 +33,10 @@ module AuthenticationSpecHelpers
   def user_token(user, token_payload)
     jwt_payload =
       {
-        'data' => { 'sub' => user.sub }.merge(token_payload),
+        'sub' => user.sub,
         'iss' => jwk[:issuer],
         'aud' => 'P4L-API'
-      }
+      }.merge(token_payload)
     JWT.encode(jwt_payload, jwk.signing_key, 'RS256', kid: jwk[:kid])
   end
 


### PR DESCRIPTION
Two fixes here, one for a model validation I missed on a previous PR and one for fixing the JWT payload in test. This also includes a change to the Authentication middleware to just look for the "sub" on the top level instead of digging into "data" first.