### PR TITLE
Isaac/signup flow

### DIFF
--- a/app/middleware/authentication.rb
+++ b/app/middleware/authentication.rb
@@ -9,27 +9,20 @@ module Authentication
     def call(env)
       access_token = extract_access_token(env)
       return unauthorized_response unless access_token
+
       decoded_access_token = JsonWebToken.new(access_token).verify!
       id_token = extract_id_token(env)
+      return unauthorized_response unless id_token
 
-      if id_token
-        id_token_json = JSON.parse(id_token)
-        email = id_token_json.dig('payload', 'email')
-      end
+      decoded_id_token = JsonWebToken.new(id_token).verify!
+      email = decoded_id_token.fetch('email')
 
-      user = User.find_or_create_by(sub: decoded_access_token.fetch('sub')) do |u|
+      user = User.find_or_create_by!(sub: decoded_access_token.fetch('sub')) do |u|
         u.email = email
-        u.save!
       end
 
-      if user
-        if email
-          if user.email != email
-            user.email = email
-            user.save!
-          end
-        end
-
+      if user.present?
+        update_user_email_if_needed(user, email)
         env[:user] = user
         @app.call(env)
       else
@@ -40,6 +33,11 @@ module Authentication
     end
 
     private
+
+    def update_user_email_if_needed(user, email)
+      user.email = email
+      user.save! if user.changed?
+    end
 
     def unauthorized_response
       Rack::Response.new({ data: '', errors: 'Unauthorized' }.to_json, 401, {}).finish

--- a/app/middleware/authentication.rb
+++ b/app/middleware/authentication.rb
@@ -23,6 +23,13 @@ module Authentication
       end
 
       if user
+        if email
+          if user.email != email
+            user.email = email
+            user.save!
+          end
+        end
+
         env[:user] = user
         @app.call(env)
       else

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class User < ActiveRecord::Base
-  validates_presence_of :first_name, :last_name, :email, :sub
+  validates_presence_of :email, :sub
   validates_uniqueness_of :email
   validates_uniqueness_of :sub
 

--- a/db/migrate/20250120172905_make_first_and_last_name_optional_for_user.rb
+++ b/db/migrate/20250120172905_make_first_and_last_name_optional_for_user.rb
@@ -1,0 +1,6 @@
+class MakeFirstAndLastNameOptionalForUser < ActiveRecord::Migration[7.1]
+  def change
+    change_column_null :users, :first_name, true
+    change_column_null :users, :last_name, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_12_14_032816) do
+ActiveRecord::Schema[7.1].define(version: 2025_01_20_172905) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -76,8 +76,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_12_14_032816) do
   end
 
   create_table "users", force: :cascade do |t|
-    t.string "first_name", null: false
-    t.string "last_name", null: false
+    t.string "first_name"
+    t.string "last_name"
     t.string "email", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/spec/middleware/authentication_spec.rb
+++ b/spec/middleware/authentication_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'Authentication middleware' do
 
   describe 'Cognito' do
     subject { Authentication::Cognito.new(app) }
-    let(:user) { create(:user) }
+    let(:user) { create(:user, email: 'original@example.com') }
     let(:env) { Rack::MockRequest.env_for }
     let(:access_token_double) do
       instance_double(
@@ -21,17 +21,32 @@ RSpec.describe 'Authentication middleware' do
         }
       )
     end
+    let(:id_token_double) do
+      instance_double(
+        JsonWebToken,
+        verify!: {
+          'sub' => user.sub,
+          'iss' => jwk[:issuer],
+          'aud' => 'P4L-API',
+          'email' => 'new@example.com'
+        }
+      )
+    end
 
     before do
       allow(JsonWebToken).to receive(:new).and_call_original
       allow(JsonWebToken).to receive(:new).with('token').and_return(
         access_token_double
       )
+      allow(JsonWebToken).to receive(:new).with('id_token').and_return(
+        id_token_double
+      )
     end
 
     context 'when the request bears a valid token' do
       before do
         env['HTTP_AUTHORIZATION'] = 'Bearer token'
+        env['HTTP_X_ID_TOKEN'] = 'Bearer id_token'
       end
 
       it 'allows access' do
@@ -46,27 +61,24 @@ RSpec.describe 'Authentication middleware' do
         expect(request_env[:user]).to eq(user)
       end
 
-      context 'when there is an ID token' do
-        let(:id_token_double) do
-          instance_double(
-            JsonWebToken,
-            verify!: { "email" => "gandalf@gmail.com" }
-          )
-        end
-
-        before do
-          env['X-ID-TOKEN'] = 'Bearer id_token'
-          allow(JsonWebToken).to receive(:new).with('id_token').and_return(
-            id_token_double
-          )
-        end
-
-        it 'sets the email for the user' do
+      context 'when the user does not exist' do
+        it 'creates a new user with the email from the ID token' do
+          user.destroy
           allow(app).to receive(:call).and_return([200, {}, 'success'])
 
           response = subject.call(env)
           expect(response).to eq([200, {}, 'success'])
-          expect(User.last.email).to include("isaac.tullos")
+          expect(User.last.email).to eq('new@example.com')
+        end
+      end
+
+      context 'when the user already exists' do
+        it 'updates the users email from the ID token' do
+          allow(app).to receive(:call).and_return([200, {}, 'success'])
+
+          response = subject.call(env)
+          expect(response).to eq([200, {}, 'success'])
+          expect(User.last.email).to eq('new@example.com')
         end
       end
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -15,22 +15,16 @@ RSpec.describe User, :model do
       expect(create_list(:user, 2).last).to be_valid
     end
 
-    it 'requires a first_name' do
+    it 'does not require a first_name' do
       user = build(:user, first_name: '')
 
-      expect(user).not_to be_valid
-      expect(user.errors.messages).to include(
-        { first_name: ['can\'t be blank'] }
-      )
+      expect(user).to be_valid
     end
 
-    it 'requires a last_name' do
+    it 'does not require a last_name' do
       user = build(:user, last_name: '')
 
-      expect(user).not_to be_valid
-      expect(user.errors.messages).to include(
-        { last_name: ['can\'t be blank'] }
-      )
+      expect(user).to be_valid
     end
 
     it 'requires an email' do

--- a/spec/requests/route_spec.rb
+++ b/spec/requests/route_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Route endpoints', :request do
   include AuthenticationSpecHelpers
 
   let(:app) { Sinatra::Application }
-  let(:user) { authenticated }
+  let!(:user) { authenticated }
 
   describe 'POST /user/routes' do
     it 'requires the auth header' do
@@ -18,7 +18,7 @@ RSpec.describe 'Route endpoints', :request do
 
     it 'creates a Route' do
       expect do
-        post '/user/routes', {}, user_token_header(user, { 'sub' => user.sub })
+        post '/user/routes', {}, headers
       end.to change { Route.count }.by(1)
       expect(last_response.status).to eq(200)
       expect(parsed_response).to include(
@@ -28,7 +28,7 @@ RSpec.describe 'Route endpoints', :request do
 
     it 'creates a Route with a nil commitment' do
       allow_any_instance_of(User).to receive(:current_commitment).and_return(nil)
-      post '/user/routes', {}, user_token_header(user, { 'sub' => user.sub })
+      post '/user/routes', {}, headers
 
       expect(last_response.status).to eq(200)
       expect(parsed_response['data']['commitment_id']).to be_nil
@@ -47,7 +47,7 @@ RSpec.describe 'Route endpoints', :request do
     end
 
     it 'updates the Route' do
-      patch "/user/routes/#{route.id}", { mileage: 130, stop: false }, user_token_header(user, { 'sub' => user.sub })
+      patch "/user/routes/#{route.id}", { mileage: 130, stop: false }, headers
 
       expect(last_response.status).to eq(200)
       expect(parsed_response).to include(
@@ -57,7 +57,7 @@ RSpec.describe 'Route endpoints', :request do
     end
 
     it 'stops the Route' do
-      patch "/user/routes/#{route.id}", { mileage: 130, stop: true }, user_token_header(user, { 'sub' => user.sub })
+      patch "/user/routes/#{route.id}", { mileage: 130, stop: true }, headers
 
       expect(last_response.status).to eq(200)
       expect(parsed_response).to include(

--- a/spec/support/helpers/authentication_spec_helpers.rb
+++ b/spec/support/helpers/authentication_spec_helpers.rb
@@ -13,6 +13,7 @@ module AuthenticationSpecHelpers
 
   def authenticated(user = FactoryBot.create(:user), token_payload = {})
     headers.merge!(user_token_header(user, token_payload))
+    headers.merge!(id_token_header(user))
     user
   end
 
@@ -23,6 +24,12 @@ module AuthenticationSpecHelpers
   def user_token_header(user, token_payload)
     {
       'HTTP_AUTHORIZATION' => "Bearer #{user_token(user, token_payload)}"
+    }
+  end
+
+  def id_token_header(user)
+    {
+      'HTTP_X_ID_TOKEN' => "Bearer #{id_token(user)}"
     }
   end
 
@@ -37,6 +44,16 @@ module AuthenticationSpecHelpers
         'iss' => jwk[:issuer],
         'aud' => 'P4L-API'
       }.merge(token_payload)
+    JWT.encode(jwt_payload, jwk.signing_key, 'RS256', kid: jwk[:kid])
+  end
+
+  def id_token(user)
+    jwt_payload = {
+      'sub' => user.sub,
+      'email' => user.email,
+      'iss' => jwk[:issuer],
+      'aud' => 'P4L-API'
+    }
     JWT.encode(jwt_payload, jwk.signing_key, 'RS256', kid: jwk[:kid])
   end
 


### PR DESCRIPTION
This PR adds the ability to create a new user with the email address from the ID token. I renamed some variables to help distinguish between the access token and id token. I'm not 100% sure but it seems like we don't even need a /signup route. I've changed my signup code on the front end to pass both tokens and it seems to be working. The last commit updates the user's email if it doesn't not match the email in the token. This should work to update the user after an email change. I feel like this commit should have some additional tests to go with it but I was a little confused when working with the authentication_spec. I'm also curious if you think there are any situations where the authentication code could run into errors or if there are any vulnerabilities with the way things are set up. Thanks!!